### PR TITLE
Fix frontend docker build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,7 @@ ARG VITE_API_URL
 FROM node:20-alpine AS build
 WORKDIR /app
 ENV VITE_API_URL=${VITE_API_URL}
-COPY package.json tsconfig.json tsconfig.app.json tsconfig.node.json vite.config.ts tailwind.config.ts postcss.config.js ./
+COPY package.json tsconfig.json tsconfig.app.json tsconfig.node.json vite.config.ts tailwind.config.ts postcss.config.js index.html ./
 COPY public ./public
 COPY src ./src
 RUN npm install && npm run build


### PR DESCRIPTION
## Summary
- include `index.html` in Docker build context so Vite can build

## Testing
- `npm run build` in `frontend`
- `npm run build` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_683f4754153c832c9af7d997d8524123